### PR TITLE
Updates ForecastSerializer to use location id as id

### DIFF
--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -30,6 +30,10 @@ class Forecast
     JSON.parse(@location.weather_days_collection.weather_days_data, symbolize_names: true)
   end
   
+  def location_id
+    @location.id
+  end
+  
   private
   
   def location

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,6 +1,6 @@
 class ForecastSerializer
   include FastJsonapi::ObjectSerializer
-  set_id :object_id
+  set_id :location_id
   attributes :city, :state, :latitude, :longitude, :date
   
   attribute :current_weather do |object|


### PR DESCRIPTION
- Updates the ForecastSerializer to use the associated location ID as its ID, rather than the object_id. 
- Adds `location_id` method to Forecast to grab the ID of its associated location
- All tests passing